### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ mono: none
 group: dev
 sudo: required
 dist: xenial
-dotnet: 2.0
+dotnet: 2.2 # 2.0 not available in travis, but 2.2 should be backward compatible
 script:
   - dotnet restore Cloo/Cloo.csproj
   - dotnet build Cloo/Cloo.csproj --configuration Release


### PR DESCRIPTION
Seems that travis does not handle 2.0 version of netcore sdk, but 2.2 should be backwards compatible...

Failing:
https://travis-ci.org/rogalmic/Cloo/builds/490191586
https://travis-ci.org/rogalmic/Cloo/jobs/490191587/config

Succeeding:
https://travis-ci.org/rogalmic/Cloo/builds/499336074
https://travis-ci.org/rogalmic/Cloo/jobs/499336075/config

Not sure if travis build is needed, but I would recommend it as great free build system with auto-deployment.