### PR TITLE
add nupkg to github release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ deploy:
       tags: true
   - provider: releases
     api_key: $GITHUB_TOKEN
-    skip_cleanup: false
+    skip_cleanup: true
+    file_glob: true
+    file: "Cloo/bin/Release/Cloo.clSharp.*.nupkg"
     on:
       branch: master
-      tags: true
-      condition: "$TRAVIS_OS_NAME == linux"
-


### PR DESCRIPTION
I would propose to add nupkg file to each github release, and build for every commit to master (test builds if you will). 
The tag for commit would trigger the real release to nuget.org.

The result of this beta build would be like:
https://github.com/rogalmic/Cloo/releases/tag/untagged-ee78311c0432acdf408c

Not sure if this is what you are aiming at, but just giving as a possibility.