### PR TITLE
Added clCreateImage for ComputeImage 

### DIFF
--- a/Cloo/Source/Bindings/CL12.cs
+++ b/Cloo/Source/Bindings/CL12.cs
@@ -42,7 +42,19 @@ namespace Cloo.Bindings
     /// <remarks> See the OpenCL specification for documentation regarding these functions. </remarks>
     [SuppressUnmanagedCodeSecurity]
     public class CL12 : CL11
-    {
+    {        
+        /// <summary>
+        /// Introduced in OpenCL 1.2.
+        /// </summary>
+        [DllImport(libName, EntryPoint = "clCreateImage")]
+        public static extern CLMemoryHandle CreateImage(
+            CLContextHandle context,
+            ComputeMemoryFlags flags,
+            ref ComputeImageFormat imageFormat,
+            ref ComputeImageDescription imageDesc,
+            IntPtr hostPointer,
+            out ComputeErrorCode resultCode);
+
         /// <summary>
         /// See the OpenCL specification.
         /// </summary>

--- a/Cloo/Source/Bindings/Enums.cs
+++ b/Cloo/Source/Bindings/Enums.cs
@@ -573,7 +573,13 @@ namespace Cloo
         /// <summary> </summary>
         Image2D = 0x10F1,
         /// <summary> </summary>
-        Image3D = 0x10F2
+        Image3D = 0x10F2,
+        Image2DArray = 0x10F3,
+        Image1D = 0x10F4,
+        Image1DArray = 0x10F5,
+        Image1DBuffer = 0x10F6,
+        Pipe = 0x10F7
+
     }
 
     /// <summary>

--- a/Cloo/Source/ComputeImage.cs
+++ b/Cloo/Source/ComputeImage.cs
@@ -43,7 +43,7 @@ namespace Cloo
     /// <remarks> A memory object that stores a two- or three- dimensional structured array. Image data can only be accessed with read and write functions. The read functions use a sampler. </remarks>
     /// <seealso cref="ComputeMemory"/>
     /// <seealso cref="ComputeSampler"/>
-    public abstract class ComputeImage : ComputeMemory
+    public class ComputeImage : ComputeMemory
     {
         #region Properties
 
@@ -86,6 +86,13 @@ namespace Cloo
         #endregion
 
         #region Constructors
+        public ComputeImage(ComputeContext context, ComputeMemoryFlags flags, ComputeImageFormat format, ComputeImageDescription desc, IntPtr data) : base(context, flags)
+        {
+            Handle = CL12.CreateImage(context.Handle, flags, ref format, ref desc, data, out ComputeErrorCode error);
+            ComputeException.ThrowOnError(error);
+
+            Init();
+        }
 
         /// <summary>
         /// 

--- a/Cloo/Source/ComputeImageDescription.cs
+++ b/Cloo/Source/ComputeImageDescription.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Cloo
+{
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ComputeImageDescription
+    {
+        public ComputeMemoryType ImageType;
+        public UIntPtr Width;
+        public UIntPtr Height;
+        public UIntPtr Depth;
+        public UIntPtr ArraySize;
+        public UIntPtr RowPitch;
+        public UIntPtr SlicePitch;
+        public uint MipLevels;
+        public uint Samples;
+        public IntPtr Buffer;
+
+        public static ComputeImageDescription Create2D(uint width, uint height)
+        {
+            return new ComputeImageDescription()
+            {
+                ImageType = ComputeMemoryType.Image2D,
+                Width = (UIntPtr)width,
+                Height = (UIntPtr)height,
+                Depth = (UIntPtr)1,
+            };
+        }
+
+        public static ComputeImageDescription Create2D(uint width, uint height, uint rowPitch)
+        {
+            return new ComputeImageDescription()
+            {
+                ImageType = ComputeMemoryType.Image2D,
+                Width = (UIntPtr)width,
+                Height = (UIntPtr)height,
+                Depth = (UIntPtr)1,
+                RowPitch = (UIntPtr)rowPitch
+            };
+        }
+
+        public static ComputeImageDescription Create3D(uint width, uint height, uint depth)
+        {
+            return new ComputeImageDescription()
+            {
+                ImageType = ComputeMemoryType.Image3D,
+                Width = (UIntPtr)width,
+                Height = (UIntPtr)height,
+                Depth = (UIntPtr)depth,
+            };
+        }
+
+        public static ComputeImageDescription Create3D(uint width, uint height, uint depth, uint rowPitch, uint slicePitch)
+        {
+            return new ComputeImageDescription()
+            {
+                ImageType = ComputeMemoryType.Image3D,
+                Width = (UIntPtr)width,
+                Height = (UIntPtr)height,
+                Depth = (UIntPtr)depth,
+                RowPitch = (UIntPtr)rowPitch,
+                SlicePitch = (UIntPtr)slicePitch
+            };
+        }
+    }
+}


### PR DESCRIPTION
added clCreateImage binding in order to create images without having to use the deprecated createImage2d(3d) added computeImageDescription struct, modified memory flag enum and deleted the abstract key from ComputeImage class.